### PR TITLE
Adds option for transparent background in settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,11 +20,15 @@
     "theme": "light"
   },
   "icon": "icon.png",
-  "categories": ["Other"],
+  "categories": [
+    "Other"
+  ],
   "engines": {
     "vscode": "^1.19.0"
   },
-  "activationEvents": ["onCommand:polacode.activate"],
+  "activationEvents": [
+    "onCommand:polacode.activate"
+  ],
   "main": "./src/extension",
   "contributes": {
     "commands": [
@@ -32,6 +36,17 @@
         "command": "polacode.activate",
         "title": "Polacode 📸"
       }
-    ]
+    ],
+    "configuration": {
+      "title": "Polacode",
+      "properties": {
+        "polacode.transparentBackground": {
+          "type": "boolean",
+          "default": false,
+          "description": "If true, code snapshot background will be transparent",
+          "scope": "window"
+        }
+      }
+    }
   }
 }

--- a/src/extension.js
+++ b/src/extension.js
@@ -37,10 +37,12 @@ function activate(context) {
       .then(() => {
         const fontFamily = vscode.workspace.getConfiguration('editor').fontFamily
         const bgColor = context.globalState.get('polacode.bgColor', '#2e3440')
+        const transparentBackground = vscode.workspace.getConfiguration("polacode").transparentBackground
         vscode.commands.executeCommand('_workbench.htmlPreview.postMessage', indexUri, {
           type: 'init',
           fontFamily,
-          bgColor
+          bgColor,
+          transparentBackground
         })
       })
   })

--- a/src/webview/index.js
+++ b/src/webview/index.js
@@ -1,6 +1,7 @@
 const snippetNode = document.getElementById('snippet')
 const snippetContainerNode = document.getElementById('snippet-container')
 const obturateur = document.getElementById('save')
+let transparentBackground = false
 
 const getInitialHtml = fontFamily => {
   const cameraWithFlashEmoji = String.fromCodePoint(128248)
@@ -111,20 +112,34 @@ document.addEventListener('paste', e => {
 })
 
 obturateur.addEventListener('click', () => {
+  const snippetContainerClone = snippetContainerNode.cloneNode(true)
+  const snippetClone = snippetContainerClone.querySelector('#snippet')
   const width = snippetContainerNode.offsetWidth * 2
   const height = snippetContainerNode.offsetHeight * 2
+
+  snippetContainerClone.style.opacity = '0'
+
+  if (transparentBackground) {
+    snippetContainerClone.style.backgroundColor = 'transparent'
+    snippetClone.style.boxShadow = 'none'
+  }
+  
   const config = {
     width,
     height,
     style: {
       transform: 'scale(2)',
-      'transform-origin': 'left top'
+      'transform-origin': 'left top',
+      opacity: 1
     }
   }
 
-  domtoimage.toBlob(snippetContainerNode, config).then(blob => {
+  document.body.appendChild(snippetContainerClone)
+
+  domtoimage.toBlob(snippetContainerClone, config).then(blob => {
     serializeBlob(blob, serializedBlob => {
       shoot(serializedBlob)
+      snippetContainerClone.remove()
     })
   })
 })
@@ -157,6 +172,7 @@ window.addEventListener('message', e => {
   if (e) {
     if (e.data.type === 'init') {
       const { fontFamily, bgColor } = e.data
+      transparentBackground = e.data.transparentBackground
 
       const initialHtml = getInitialHtml(fontFamily)
       snippetNode.innerHTML = initialHtml


### PR DESCRIPTION
Adds option for transparent background in settings.

This doesn't change anything in the way the webview appears for the user, a background is still shown if this option is turned on for readability purposes.

If turned on the saved image background becomes transparent and the box shadow disappears.

Fixes [#55](https://github.com/octref/polacode/issues/55)