### PR TITLE
fix: Long text truncation

### DIFF
--- a/webview/index.html
+++ b/webview/index.html
@@ -23,6 +23,12 @@
       padding-bottom: 22px;
       border-radius: 5px;
       box-shadow: rgba(0, 0, 0, 0.55) 0px 20px 68px;
+      max-width: 700px;
+    }
+    #snippet > div {
+        max-width: 100%;
+        white-space: pre-wrap !important;
+        word-break: break-all;
     }
     #snippet > div > div {
       display: flex;


### PR DESCRIPTION
Error when a line is too long.

Maybe we need a slider to control the width.

Before:
![bug](https://user-images.githubusercontent.com/13498329/56707690-71724380-674c-11e9-9e47-6cb4c011f8b9.jpg)

After:
![fixed](https://user-images.githubusercontent.com/13498329/56707694-73d49d80-674c-11e9-943d-8594c5ba0720.jpg)
