### PR TITLE
fix: default crop

### DIFF
--- a/webview/index.html
+++ b/webview/index.html
@@ -32,8 +32,8 @@
       resize: both;
       display: flex;
       padding: 18px;
-      margin: 22px;
-      padding-bottom: 22px;
+      margin-top: 64px;
+      margin-bottom: 64px;
       border-radius: 5px;
       box-shadow: rgba(0, 0, 0, 0.55) 0px 20px 68px;
       width: calc(100% - 8rem);


### PR DESCRIPTION
There is already perfect defaults except margins that crop the shadow and it's not related to #77.

Personally I regret using any settings (and this was the purpose of this extension) because nothing can beat the default shadow and resizing the canvas everytime I want to take a screenshot it's not really an option. 

![code](https://user-images.githubusercontent.com/30002276/57231186-b63a8c00-7022-11e9-8c36-9c656c845918.png)
