### PR TITLE
Fix: does not work on VSCode 1.47.0 and later

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -22,7 +22,7 @@ function activate(context) {
   vscode.window.registerWebviewPanelSerializer('polacode', {
     async deserializeWebviewPanel(_panel, state) {
       panel = _panel
-      panel.webview.html = getHtmlContent(htmlPath)
+      panel.webview.html = getHtmlContent()
       panel.webview.postMessage({
         type: 'restore',
         innerHTML: state.innerHTML,
@@ -42,7 +42,7 @@ function activate(context) {
       localResourceRoots: [vscode.Uri.file(path.join(context.extensionPath, 'webview'))]
     })
 
-    panel.webview.html = getHtmlContent(htmlPath)
+    panel.webview.html = getHtmlContent()
 
     const selectionListener = setupSelectionSync()
     panel.onDidDispose(() => {
@@ -130,7 +130,7 @@ function activate(context) {
     })
   }
 
-  function getHtmlContent(htmlPath) {
+  function getHtmlContent() {
     const htmlContent = fs.readFileSync(htmlPath, 'utf-8')
     const absolutePath = vscode.Uri.file(context.asAbsolutePath('./webview'))
     const webviewPath = panel.webview.asWebviewUri(absolutePath).toString()

--- a/src/extension.js
+++ b/src/extension.js
@@ -14,6 +14,7 @@ const P_TITLE = 'Polacode 📸'
  * @param {vscode.ExtensionContext} context
  */
 function activate(context) {
+  const outputChannel = vscode.window.createOutputChannel(P_TITLE)
   const htmlPath = path.resolve(context.extensionPath, 'webview/index.html')
 
   let lastUsedImageUri = vscode.Uri.file(path.resolve(homedir(), 'Desktop/code.png'))
@@ -129,6 +130,9 @@ function activate(context) {
       }
     })
   }
+
+  outputChannel.appendLine(`${P_TITLE} activated`)
+  outputChannel.show();
 }
 
 function getHtmlContent(htmlPath) {

--- a/src/extension.js
+++ b/src/extension.js
@@ -14,7 +14,6 @@ const P_TITLE = 'Polacode 📸'
  * @param {vscode.ExtensionContext} context
  */
 function activate(context) {
-  const outputChannel = vscode.window.createOutputChannel(P_TITLE)
   const htmlPath = path.resolve(context.extensionPath, 'webview/index.html')
 
   let lastUsedImageUri = vscode.Uri.file(path.resolve(homedir(), 'Desktop/code.png'))
@@ -131,16 +130,13 @@ function activate(context) {
     })
   }
 
-  outputChannel.appendLine(`${P_TITLE} activated`)
-  outputChannel.show();
-}
-
-function getHtmlContent(htmlPath) {
-  const htmlContent = fs.readFileSync(htmlPath, 'utf-8')
-  return htmlContent.replace(/script src="([^"]*)"/g, (match, src) => {
-    const realSource = 'vscode-resource:' + path.resolve(htmlPath, '..', src)
-    return `script src="${realSource}"`
-  })
+  function getHtmlContent(htmlPath) {
+    const htmlContent = fs.readFileSync(htmlPath, 'utf-8')
+    const absolutePath = vscode.Uri.file(context.asAbsolutePath('./webview'))
+    const webviewPath = panel.webview.asWebviewUri(absolutePath).toString()
+  
+    return htmlContent.replace(/{{root}}/g, webviewPath);
+  }
 }
 
 exports.activate = activate

--- a/webview/index.html
+++ b/webview/index.html
@@ -96,8 +96,8 @@
     </svg>
   </div>
 
-  <script src="./dom2image.js"></script>
-  <script src="./vivus.js"></script>
-  <script src="./index.js"></script>
+  <script src="{{root}}/dom2image.js"></script>
+  <script src="{{root}}/vivus.js"></script>
+  <script src="{{root}}/index.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Fixes #143 

I spent a couple of hours and figured out that everything works correctly on `macOs`. Then I opened this extension on `Windows 10` and `VSCode 1.47.2` in debugger mode and saw several errors that said that the path to the JavaScript files was incorrect. I took as a basis the path handling methods in this case from the [vscode-azure-blockchain-ethereum](https://github.com/microsoft/vscode-azure-blockchain-ethereum) repository

Tested on `Windows 10` and `macOs Catalina`

As a workaround, you can use my hotfix extension:
https://marketplace.visualstudio.com/items?itemName=mrrefactoring.polacode-fixed-edition