### PR TITLE
adds cursor:pointer to obturateur for better UX

### DIFF
--- a/webview/index.html
+++ b/webview/index.html
@@ -59,6 +59,7 @@
     .obturateur {
       width: 64px;
       height: 64px;
+      cursor: pointer;
     }
     .obturateur * {
       transition: stroke .4s;


### PR DESCRIPTION
Clickable elements should have a different cursor to indicate click-ability. The obturateur was missing such.